### PR TITLE
virtualbox: handle a list of bridged nics

### DIFF
--- a/plugins/providers/virtualbox/action/network.rb
+++ b/plugins/providers/virtualbox/action/network.rb
@@ -157,14 +157,18 @@ module VagrantPlugins
             @logger.debug("Bridge was directly specified in config, searching for: #{config[:bridge]}")
 
             # Search for a matching bridged interface
-            bridge = config[:bridge]
-            bridge = bridge.downcase if bridge.respond_to?(:downcase)
-            bridgedifs.each do |interface|
-              if bridge === interface[:name].downcase
-                @logger.debug("Specific bridge found as configured in the Vagrantfile. Using it.")
-                chosen_bridge = interface[:name]
-                break
+            bridges = config[:bridge]
+            bridges = [bridges] if not bridges.respond_to?(:each)
+            bridges.each do |bridge|
+              bridge = bridge.downcase if bridge.respond_to?(:downcase)
+              bridgedifs.each do |interface|
+                if bridge === interface[:name].downcase
+                  @logger.debug("Specific bridge found as configured in the Vagrantfile. Using it.")
+                  chosen_bridge = interface[:name]
+                  break
+                end
               end
+              break if chosen_bridge
             end
 
             # If one wasn't found, then we notify the user here.


### PR DESCRIPTION
This change allows you to specify multiple network interfaces to bridge
to, picking the first found.

``` ruby
config.vm.network "public_network",
  bridge: ["en4: Thunderbolt Ethernet",
           "en6: Broadcom NetXtreme Gigabit Ethernet Controller",
           "en0: Wi-Fi (AirPort)"]
```
